### PR TITLE
fix(Edit-File): detect devenv ancestor for VS terminal, add sensitive marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,22 @@ $env:BUILD_APPX_RECIPE     = ".\BuildResults\{0}-{1}\{2}Package\bin\{2}Package\{
 dpb -UserParam01 TV -Target "Apps\TV\TVPackage" -Configuration Debug -Platform x64
 ```
 
+## Invoking Build Commands
+
+**Never pipe `build`, `dpb`, or any PwrDev build command through `| Out-String` or `2>&1 | Out-String`.**
+
+These commands use MSBuild's terminal logger (`-tl`) which writes live output directly to the terminal. Piping through `Out-String` breaks that output. Run them bare:
+
+```powershell
+# CORRECT
+build
+dpb -Configuration Release
+
+# WRONG — breaks terminal logger output
+build 2>&1 | Out-String
+dpb -Configuration Release 2>&1 | Out-String
+```
+
 ## WSL Behavior
 
 - `build` auto-detects C++ projects (`.vcxproj`) and re-invokes on Windows from WSL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ This module's source files are in `$_.ModuleBase` (e.g. `Modules\PwrDev\`). Key 
 | `Enter-VsShell` | Initialize Visual Studio developer shell |
 | `goerror` / `Edit-BuildErrors` | Open build error(s) in editor |
 | `Get-BuildErrors` | List build errors as objects |
-| `edit` / `Edit-File` | Open file at line in terminal-aware editor |
+| `ef` / `Edit-File` | Open file at line in terminal-aware editor |
 | `Get-RepoRoot` | Find the git repository root |
 | `Confirm-DevMode` | Check Windows Developer Mode status |
 | `Setup-DevMode` | Enable Windows Developer Mode (admin) |
@@ -56,7 +56,7 @@ goerror
 goerror -first 2 -skip 1
 
 # Open a file at a line
-edit src\foo.cpp 42
+ef src\foo.cpp 42
 ```
 
 ## Environment Variables
@@ -96,12 +96,19 @@ dpb -Configuration Release 2>&1 | Out-String
 
 ## Editor Behavior (`Edit-File`)
 
-| Terminal | Editor used |
-|----------|-------------|
-| Visual Studio (DevHub) | VS DTE — opens in running VS instance |
-| VS Code | `code --goto file:line` |
-| Claude Code | `Start-Process vim.exe` (new window) |
-| Other | `vim.exe` inline |
+**SENSITIVE — do not modify `Edit-File.ps1` without testing all three terminal contexts:**
+1. **Visual Studio terminal** (Claude Code running inside VS) → must open in VS via DTE
+2. **Claude Code with redirected stdin** (standalone Claude Code, VS running in background) → must open vim in a new window
+3. **Plain terminal** (PowerShell, Windows Terminal, no VS) → must open vim inline
+
+This file has broken multiple times. Always test all three cases before committing any change.
+
+| Priority | Condition | Editor used |
+|----------|-----------|-------------|
+| 1 | `devenv` or `DevHub` in ancestor process tree | VS DTE — opens in running VS instance |
+| 2 | stdin redirected (`[Console]::IsInputRedirected`) | `Start-Process vim.exe` (new window) |
+| 3 | `$env:TERM_PROGRAM -eq "vscode"` | `code --goto file:line` |
+| 4 | Other | `vim.exe` inline |
 
 ## Branch and PR Policy (release-please)
 

--- a/Edit-File.ps1
+++ b/Edit-File.ps1
@@ -7,6 +7,14 @@ param(
   [int]$LineNumber = 0
 )
 
+# SENSITIVE: This file has been extensively tested across three terminal contexts:
+#   1. Visual Studio terminal (devenv ancestor) → DTE opens file in running VS instance
+#   2. Claude Code / redirected stdin           → vim launched in new window via Start-Process
+#   3. Plain terminal                           → vim runs inline
+#
+# The terminal detection logic is fragile and must be tested in ALL three contexts
+# before committing any change. Do not modify detection heuristics without testing.
+
 # Marshal.GetActiveObject was removed in .NET Core - use oleaut32 P/Invoke instead
 if (-not ([System.Management.Automation.PSTypeName]'ComHelper').Type) {
   Add-Type -TypeDefinition @'
@@ -37,7 +45,7 @@ function Test-IsVisualStudioTerminal {
       $proc = $proc.Parent
       if ($null -eq $proc) { break }
       Write-Verbose "Checking ancestor process: $($proc.ProcessName)"
-      if ($proc.ProcessName -eq 'DevHub') { return $true }
+      if ($proc.ProcessName -eq 'DevHub' -or $proc.ProcessName -eq 'devenv') { return $true }
     }
   } catch {}
   return $false

--- a/Edit-File.ps1
+++ b/Edit-File.ps1
@@ -7,21 +7,6 @@ param(
   [int]$LineNumber = 0
 )
 
-function Test-IsVisualStudioTerminal {
-  try {
-    $proc = Get-Process -Id $PID
-    $maxDepth = 5
-    for ($i = 0; $i -lt $maxDepth; $i++) {
-      $proc = $proc.Parent
-      if ($null -eq $proc) { break }
-      Write-Verbose "Checking ancestor process: $($proc.ProcessName)"
-      if ($proc.ProcessName -eq 'DevHub') { return $true }
-    }
-  } catch {}
-  return $false
-}
-
-
 # Marshal.GetActiveObject was removed in .NET Core - use oleaut32 P/Invoke instead
 if (-not ([System.Management.Automation.PSTypeName]'ComHelper').Type) {
   Add-Type -TypeDefinition @'
@@ -44,38 +29,29 @@ public class ComHelper {
 '@
 }
 
+function Test-IsVisualStudioTerminal {
+  try {
+    $proc = Get-Process -Id $PID
+    $maxDepth = 5
+    for ($i = 0; $i -lt $maxDepth; $i++) {
+      $proc = $proc.Parent
+      if ($null -eq $proc) { break }
+      Write-Verbose "Checking ancestor process: $($proc.ProcessName)"
+      if ($proc.ProcessName -eq 'DevHub') { return $true }
+    }
+  } catch {}
+  return $false
+}
 
 if ($null -ne $resolvedPath) {
   $FilePath = $resolvedPath.Path
 }
 Write-Verbose "FilePath: $FilePath, LineNumber: $LineNumber"
 
-# 1. Running inside a Claude Code session, or stdin is redirected (piped/CI) -
-# launch editor in a new window so it can attach to its own terminal.
-# Checked first - cheap, and avoids unnecessary CIM queries below.
-if ($env:CLAUDE_CODE_ACTIVE -eq '1' -or [Console]::IsInputRedirected) {
-  Write-Verbose "Terminal: Claude / redirected stdin - launching editor in new window via Start-Process"
-  $vimPath = Get-Command vim -CommandType Application -ErrorAction Ignore
-  if ($null -ne $vimPath) {
-    $editorArgs = if ($LineNumber -gt 0) { @($FilePath, "+$LineNumber") } else { @($FilePath) }
-    Write-Verbose "Using vim ($($vimPath.Source)) args: $editorArgs"
-    Start-Process -FilePath $vimPath.Source -ArgumentList $editorArgs
-    return
-  }
-  $editPath = Get-Command edit -CommandType Application -ErrorAction Ignore
-  if ($null -ne $editPath) {
-    $editorArgs = if ($LineNumber -gt 0) { @($FilePath, $LineNumber) } else { @($FilePath) }
-    Write-Verbose "Using edit ($($editPath.Source)) args: $editorArgs"
-    Start-Process -FilePath $editPath.Source -ArgumentList $editorArgs
-    return
-  }
-  Write-Warning "No editor found. Install edit or vim to open files from the terminal."
-  return
-}
-
-# 2. Visual Studio integrated terminal (requires CIM query to walk process tree)
+# 1. Visual Studio integrated terminal (DevHub ancestor) - use DTE.
+# DTE is only used when running inside VS's own terminal. When VS is open in the
+# background but you're in a separate terminal, ef opens vim there instead.
 if (Test-IsVisualStudioTerminal) {
-  Write-Verbose "Terminal: Visual Studio (DevHub parent) - using DTE"
   $dteProgIds = @("VisualStudio.DTE.18.0", "VisualStudio.DTE.17.0", "VisualStudio.DTE.16.0", "VisualStudio.DTE.15.0", "VisualStudio.DTE")
   $dte = $null
   foreach ($progId in $dteProgIds) {
@@ -88,27 +64,32 @@ if (Test-IsVisualStudioTerminal) {
     }
   }
   if ($null -ne $dte) {
-    $window = $dte.ItemOperations.OpenFile($FilePath)
-    $window.Activate()
-    if ($LineNumber -gt 0) {
-      $doc = $dte.ActiveDocument
-      if ($null -eq $doc) {
-        try { $doc = $dte.Documents.Item($FilePath) } catch {}
+    try {
+      $window = $dte.ItemOperations.OpenFile($FilePath)
+      $window.Activate()
+      if ($LineNumber -gt 0) {
+        $doc = $dte.ActiveDocument
+        if ($null -eq $doc) {
+          try { $doc = $dte.Documents.Item($FilePath) } catch {}
+        }
+        if ($null -ne $doc) {
+          $doc.Activate()
+          $doc.Selection.GotoLine($LineNumber, $false)
+        } else {
+          Write-Warning "File opened but could not navigate to line $LineNumber"
+        }
       }
-      if ($null -ne $doc) {
-        $doc.Activate()
-        $doc.Selection.GotoLine($LineNumber, $false)
-      } else {
-        Write-Warning "File opened but could not navigate to line $LineNumber"
-      }
+      return
+    } catch {
+      Write-Warning "DTE OpenFile failed: $_. Falling back to editor."
     }
-    return
+  } else {
+    Write-Warning "Could not connect to any Visual Studio DTE instance."
   }
-  Write-Warning "Could not connect to any Visual Studio DTE instance."
   return
 }
 
-# 3. VS Code terminal
+# 2. VS Code terminal
 if ($env:TERM_PROGRAM -eq "vscode") {
   $gotoParam = if ($LineNumber -gt 0) { "${FilePath}:${LineNumber}" } else { $FilePath }
   Write-Verbose "Terminal: VS Code - code --goto $gotoParam"
@@ -116,7 +97,22 @@ if ($env:TERM_PROGRAM -eq "vscode") {
   return
 }
 
-# 4. Other terminals: vim, then edit
+# 3. Stdin is redirected (piped/CI or terminal owned by another process) -
+# launch editor in a new window so it can attach to its own terminal.
+if ([Console]::IsInputRedirected) {
+  Write-Verbose "stdin redirected - launching editor in new window via Start-Process"
+  $vimPath = Get-Command vim -CommandType Application -ErrorAction Ignore
+  if ($null -ne $vimPath) {
+    $editorArgs = if ($LineNumber -gt 0) { @($FilePath, "+$LineNumber") } else { @($FilePath) }
+    Write-Verbose "Using vim ($($vimPath.Source)) args: $editorArgs"
+    Start-Process -FilePath $vimPath.Source -ArgumentList $editorArgs
+    return
+  }
+  Write-Warning "No editor found. Install vim to open files from the terminal."
+  return
+}
+
+# 4. Other terminals: vim inline
 $vimPath = Get-Command vim -CommandType Application -ErrorAction Ignore
 if ($null -ne $vimPath) {
   Write-Verbose "Terminal: other - using vim ($($vimPath.Source))"
@@ -128,15 +124,4 @@ if ($null -ne $vimPath) {
   return
 }
 
-$editPath = Get-Command edit -CommandType Application -ErrorAction Ignore
-if ($null -ne $editPath) {
-  Write-Verbose "Terminal: other - using edit ($($editPath.Source))"
-  if ($LineNumber -gt 0) {
-    & $editPath.Source $FilePath $LineNumber
-  } else {
-    & $editPath.Source $FilePath
-  }
-  return
-}
-
-Write-Warning "No editor found. Install edit or vim to open files from the terminal."
+Write-Warning "No editor found. Install vim to open files from the terminal."


### PR DESCRIPTION
## Summary
- Fix `Test-IsVisualStudioTerminal` to also match `devenv` in the ancestor process chain — modern VS installations don't have `DevHub` as a direct ancestor
- Replace unreliable `CLAUDE_CODE_ACTIVE` env var check (always inherited by subprocesses) with `[Console]::IsInputRedirected`
- Rename alias docs from `edit` to `ef`
- Mark `Edit-File.ps1` as sensitive in both source header and CLAUDE.md with a test checklist, since this file has broken multiple times

## Test plan
- [x] VS terminal (Claude Code inside VS): `ef <file> <line>` opens in running VS instance via DTE
- [x] Standalone Claude Code (stdin redirected): opens vim in new window
- [x] Plain terminal (PowerShell/Windows Terminal): opens vim inline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)