### PR TITLE
fix(ef): pipe Get-Command vim through Select-Object -First 1

### DIFF
--- a/Edit-File.ps1
+++ b/Edit-File.ps1
@@ -107,7 +107,7 @@ if ($env:TERM_PROGRAM -eq "vscode") {
 
 # Helper: locate vim.exe — checks PATH first, then common Windows install locations.
 function Find-VimExe {
-  $cmd = Get-Command vim -CommandType Application -ErrorAction Ignore
+  $cmd = Get-Command vim -CommandType Application -ErrorAction Ignore | Select-Object -First 1
   if ($null -ne $cmd) { return $cmd.Source }
   $candidates = @(
     "$env:ProgramFiles\Vim\vim*\vim.exe",


### PR DESCRIPTION
Prevents ambiguous match error when multiple vim entries exist on PATH.