### PR TITLE
feat(build): add Invoke-GradleBuild and extract Invoke-MsBuild dispatcher

### DIFF
--- a/Get-BuildErrors.ps1
+++ b/Get-BuildErrors.ps1
@@ -1,58 +1,90 @@
 [CmdLetBinding()]
 param(
-  [switch]$IncludeWarnings
+    [switch]$IncludeWarnings
 )
 
-if (Test-Path env:lastBuildLog) {
-  $baseLog = $env:lastBuildLog
-} else {
-  $vsDir = Join-Path (Get-RepoRoot) '.vs'
-  $lastErr = Get-ChildItem (Join-Path $vsDir 'build.*.err') -ErrorAction SilentlyContinue |
-    Sort-Object LastWriteTime |
-    Select-Object -Last 1
-  if ($null -eq $lastErr) {
-    if (Test-Path env:_BuildType) {
-      $buildErrorsDir = if ($null -ne $global:lastBuildDir) { $global:lastBuildDir } else { ".\" }
-      $baseLog = $buildErrorsDir + "\build" + $env:_BuildType
-    } else {
-      Write-Error "No build error files found. Run a build first."
-      return
+function ConvertTo-BuildDiagnostic {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [string]$Line
+    )
+    process {
+        # MSBuild: [> ]path(line[,col]): error|warning CODE: message
+        if ($Line -match '([^(>]+)\((\d+)(?:,(\d+))?\):\s*(error|warning)\s+(\w+):\s*(.+)') {
+            return [PSCustomObject]@{
+                PSTypeName = 'PwrDev.BuildDiagnostic'
+                Severity   = $Matches[4]
+                File       = (Get-Item $Matches[1].Trim() -ErrorAction SilentlyContinue) ?? $Matches[1].Trim()
+                LineNumber = [int]$Matches[2]
+                Column     = if ($Matches[3]) { [int]$Matches[3] } else { 0 }
+                Code       = $Matches[5]
+                Message    = $Matches[6].Trim()
+                RawLine    = $Line
+            }
+        }
+
+        # Kotlin: e:|w: file:///path:line:col: error|warning: message
+        if ($Line -match '^[ew]:\s+file:///(.+):(\d+):(\d+):\s*(error|warning):\s*(.+)') {
+            return [PSCustomObject]@{
+                PSTypeName = 'PwrDev.BuildDiagnostic'
+                Severity   = $Matches[4]
+                File       = (Get-Item $Matches[1] -ErrorAction SilentlyContinue) ?? $Matches[1]
+                LineNumber = [int]$Matches[2]
+                Column     = [int]$Matches[3]
+                Code       = ''
+                Message    = $Matches[5].Trim()
+                RawLine    = $Line
+            }
+        }
+
+        # C/C++ (clang via Gradle CMake): [C/C++: ]drive:/path:line:col: error|warning: message
+        if ($Line -match '^(?:C/C\+\+:\s+)?([A-Za-z]:[/\\][^:]+):(\d+):(\d+):\s*(error|warning):\s*(.+)') {
+            return [PSCustomObject]@{
+                PSTypeName = 'PwrDev.BuildDiagnostic'
+                Severity   = $Matches[4]
+                File       = (Get-Item $Matches[1] -ErrorAction SilentlyContinue) ?? $Matches[1]
+                LineNumber = [int]$Matches[2]
+                Column     = [int]$Matches[3]
+                Code       = ''
+                Message    = $Matches[5].Trim()
+                RawLine    = $Line
+            }
+        }
     }
-  } else {
-    $baseLog = [System.IO.Path]::Combine($lastErr.DirectoryName, [System.IO.Path]::GetFileNameWithoutExtension($lastErr.FullName))
-  }
+}
+
+if (Test-Path env:lastBuildLog) {
+    $baseLog = $env:lastBuildLog
+} else {
+    $vsDir   = Join-Path (Get-RepoRoot) '.vs'
+    $lastErr = Get-ChildItem (Join-Path $vsDir 'build.*.err') -ErrorAction SilentlyContinue |
+                 Sort-Object LastWriteTime |
+                 Select-Object -Last 1
+    if ($null -eq $lastErr) {
+        if (Test-Path env:_BuildType) {
+            $buildErrorsDir = if ($null -ne $global:lastBuildDir) { $global:lastBuildDir } else { ".\" }
+            $baseLog = $buildErrorsDir + "\build" + $env:_BuildType
+        } else {
+            Write-Error "No build error files found. Run a build first."
+            return
+        }
+    } else {
+        $baseLog = [System.IO.Path]::Combine(
+            $lastErr.DirectoryName,
+            [System.IO.Path]::GetFileNameWithoutExtension($lastErr.FullName))
+    }
 }
 
 $errFile = "$baseLog.err"
 $wrnFile = "$baseLog.wrn"
 
-if (!(Test-Path $errFile)) {
-  Write-Verbose "Build error file not found: $errFile"
-  return
-}
-
-Write-Verbose "Errors from: $errFile"
-Get-Content $errFile | Where-Object { $_ -like "*(*)*: error *" } | ForEach-Object {
-  $fileStart = $_.IndexOf(">")
-  $fileEnd = $_.IndexOf("(")
-  $fileName = $_.SubString($fileStart + 1, $fileEnd - $fileStart - 1)
-  $lineNumberEnd = $_.IndexOf(")")
-  $lineNumber = $_.SubString($fileEnd + 1, $lineNumberEnd - $fileEnd - 1)
-  $errorStart = $_.IndexOf(": ")
-  $errorDescription = $_.SubString($errorStart + 2)
-  $columnNumberStart = $lineNumber.IndexOf(",")
-  if (-1 -ne $columnNumberStart) {
-    $lineNumber = $lineNumber.substring(0, $columnNumberStart)
-  }
-  $fileItem = Get-Item $fileName -ErrorAction SilentlyContinue
-  return [PSCustomObject]@{
-    File       = $fileItem
-    LineNumber = $lineNumber
-    Error      = $errorDescription
-  }
+if (Test-Path $errFile) {
+    Write-Verbose "Errors from: $errFile"
+    Get-Content $errFile | ConvertTo-BuildDiagnostic
 }
 
 if ($IncludeWarnings -and (Test-Path $wrnFile)) {
-  Write-Host "Warnings from: $wrnFile"
-  Get-Content $wrnFile
+    Write-Verbose "Warnings from: $wrnFile"
+    Get-Content $wrnFile | ConvertTo-BuildDiagnostic
 }

--- a/Invoke-BuildTool.ps1
+++ b/Invoke-BuildTool.ps1
@@ -1,5 +1,6 @@
 [CmdLetBinding()]
 param(
+  # MSBuild params — passed through to Invoke-MsBuild.ps1
   [switch]$NoRestore,
   [switch]$clean,
   [switch]$noBuild,
@@ -31,7 +32,7 @@ param(
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
       'Quiet','Minimal','Normal','Detailed','Diagnostic' |
         Where-Object { $_ -like "$wordToComplete*" }
-    })]  
+    })]
   [string]$ConsoleVerbosity = "Minimal",
   [Parameter()]
   [ValidateSet('Quiet','Minimal','Normal','Detailed','Diagnostic')]
@@ -39,275 +40,52 @@ param(
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
       'Quiet','Minimal','Normal','Detailed','Diagnostic' |
         Where-Object { $_ -like "$wordToComplete*" }
-    })]  
-  [string]$Verbosity='Diagnostic',
-  [string]$ConsoleLoggerParameters = "Verbosity=${ConsoleVerbosity}"
+    })]
+  [string]$Verbosity = 'Diagnostic',
+  [string]$ConsoleLoggerParameters = "Verbosity=${ConsoleVerbosity}",
+
+  # Gradle-specific params (only used when a Gradle project is detected)
+  [string[]] $Tasks
 )
 
 begin {
-  function Test-IsGitRepo { ($null -ne (Get-RepoRoot)) }
+  $wrapperName = if ($IsWindows) { 'gradlew.bat' } else { 'gradlew' }
 
-  function Test-SymLinks {
-    $testDir = [System.IO.Path]::GetTempPath()
-    $testLink = Join-Path $testDir "symlink-test-$PID"
-    $testTarget = Join-Path $testDir "symlink-target-$PID"
-    try {
-      New-Item -ItemType Directory -Path $testTarget -Force | Out-Null
-      New-Item -ItemType SymbolicLink -Path $testLink -Target $testTarget -ErrorAction Stop | Out-Null
-      return $true
-    } catch {
-      return $false
-    } finally {
-      Remove-Item -LiteralPath $testLink -Force -ErrorAction SilentlyContinue
-      Remove-Item -LiteralPath $testTarget -Force -ErrorAction SilentlyContinue
-    }
-  }
+  # Two-level Gradle detection: wrapper first, then build script + system gradle.
+  $gradleWrapper = $null
 
-  $script:canCreateSymLinks = Test-SymLinks
-  Write-Verbose "SymLink support: $script:canCreateSymLinks"
-
-  Write-Verbose "Begin"
-
-  # If running inside WSL and the repo contains C++ projects, re-run on the Windows side.
-  if ($env:WSL_DISTRO_NAME) {
-    if (Get-ChildItem *.vcxproj -File -Recurse -Depth 3 | Select-Object -First 1) {
-      Invoke-OnWindowsIfWsl -ScriptPath $MyInvocation.MyCommand.Path -BoundParameters $PSBoundParameters
-    }
-  }
-
-  Enter-VsShell | Write-Verbose
-
-  $script:errorLevel = 0
-
-  if (-not $PSBoundParameters.ContainsKey('baseResultDir')) {
-    $baseResultDir = Join-Path (Get-RepoRoot) '.vs'
-  }
-
-  if (-Not (Test-Path $baseResultDir)) {
-    New-Item $baseResultDir -ItemType Directory | Out-Null
-  }
-
-  $script:msBuildArgs = @()
-
-  if (-Not $noParallel) {
-    Write-Verbose "Running in parallel"
-    $msbuildArgs += "/m"
-  }
-  if (-Not $rawOutput) {
-    Write-Verbose "Using new terminal output"
-    $msbuildArgs += "/tl"
-  }
-  if (-Not $enableAutoResponse) {
-    Write-Verbose "Not using auto response files"
-    $msbuildArgs += "-noautoresponse"
-  }
-  if ($noConsoleLogger) {
-    Write-Verbose "Disabling console logger"
-    $msbuildArgs += "-noconsolelogger"
-  }
-  if ("" -ne $ConsoleLoggerParameters) {
-    Write-Verbose "Settings console logging parameters:$ConsoleLoggerParameters"
-    $msbuildArgs += "-clp:$ConsoleLoggerParameters"
-  }
-  if ("" -ne $Target) {
-    Write-Verbose "Build target:$Target"
-    $msbuildArgs += "/t:$Target"
-  }
-
-  # Build the /p: arguments
-  $msBuildArgs += $Properties.GetEnumerator() | ForEach-Object {
-    $key = $_.Key
-    $value = $_.Value
-    Write-Verbose "Setting property: $key -> $value"
-    "/p:$Key=$Value"
-  }
-
-  if (("" -eq $Platform) -and (Test-IsGitRepo)) {
-    Write-Verbose "Setting platform:$Platform"
-    $hasCpp = Get-ChildItem *.vcxproj -File -Recurse -Depth 3 | Select-Object -First 1
-    if ($hasCpp) {
-      $Platform = if ($hasCpp) { $env:PROCESSOR_ARCHITECTURE } else { "AnyCPU" }
-      if ($Platform -eq "AMD64") { $Platform = "X64" }
-    }
-  }
-  if ("" -ne $Platform) {
-    $msBuildArgs += "/p:Platform=$Platform"
-    Write-Verbose "Platform:$Platform"
-  }
-
-  if ("" -ne $Configuration) {
-    Write-Verbose "Setting config:$Configuration"
-    $msBuildArgs += "/p:Configuration=$Configuration"
-  }
-
-  if ((-Not $NoRestore)) {
-    Write-Verbose "Setting restore flag"
-    $msBuildArgs += "-restore"
-  }
-
-  $bPath = (pwd).Path
-  $dir = $bPath
-
-  if ("auto" -eq $Project) {
-    Write-Verbose ("Looking for project in directory:{0}" -f $dir)
-    $projectItem = Get-ChildItem -File (
-      (Join-Path $dir '*.sln*'),
-      (Join-Path $dir '*.*proj')) | Select-Object -First 1
-    if ($null -eq $projectItem) {
-      Write-Error "Project not found in $dir"
-      $script:errorLevel = 404
-      return
-    }
+  $candidate = Join-Path (Get-Location).Path $wrapperName
+  if (Test-Path $candidate) {
+    $gradleWrapper = $candidate
+    Write-Verbose "Detected Gradle wrapper: $gradleWrapper"
   } else {
-    $projectItem = Get-Item $Project
-  }
-
-  $script:errorLevel = 0
-}
-
-process {
-
-  function Get-GlobalPackagesFolder {
-    param($dir)
-    $nugetConfigPath = Join-Path $dir 'nuget.config'
-    if (Test-Path $nugetConfigPath) {
-      $nugetGConfig = [xml](Get-Content $nugetConfigPath)
-      $nugetConfig = $nugetGConfig.configuration.config.add
-      if ($null -ne $nugetConfig) {
-        return $nugetConfig.GetEnumerator() | where { $_.key -eq "globalPackagesFolder" } | select -ExpandProperty value
+    $gradleScript = Get-Item 'build.gradle','build.gradle.kts','settings.gradle','settings.gradle.kts' `
+                      -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($gradleScript) {
+      Write-Verbose "Gradle build script found ($($gradleScript.Name)); looking for system gradle."
+      $sysGradle = Get-Command gradle -ErrorAction SilentlyContinue
+      if ($sysGradle) {
+        $gradleWrapper = $sysGradle.Source
+        Write-Verbose "Using system gradle: $gradleWrapper"
+      } else {
+        Write-Warning "Gradle project found but no wrapper and 'gradle' not on PATH; falling back to MSBuild detection."
       }
     }
-    return $null
   }
 
-  if (0 -ne $script:errorLevel) {
-    Write-Verbose ("Already failed with error code {0}" -f $script:errorLevel)
+  if ($gradleWrapper) {
+    $gradleParams = @{}
+    if ($PSBoundParameters.ContainsKey('Tasks'))         { $gradleParams['Tasks']         = $Tasks }
+    if ($PSBoundParameters.ContainsKey('Configuration')) { $gradleParams['Configuration'] = $Configuration }
+    if ($PSBoundParameters.ContainsKey('clean'))         { $gradleParams['Clean']         = $clean }
+    & "$PSScriptRoot\Invoke-GradleBuild.ps1" @gradleParams
     return
   }
 
-  Write-Verbose ("Building project:{0}" -f $projectItem.FullName)
-
-  $time = [datetime]::Now.ToString("yy.dd.MM-HH.mm.ss")
-  $br = git branch --show-current
-  $br = ($br -split '/') | Select-Object -Last 1
-  if ("" -ne $id) {
-    $br += ".$id"
-  }
-
-  $projName = $projectItem.BaseName
-  $resultDir = "$baseResultDir"
-  New-Item $resultDir -ItemType Directory -ErrorAction Ignore | Out-Null
-  $tN = ($target -split '\\') | Select-Object -Last 1
-  $tN = $tN.Replace(":",".")
-  $suffixName = (($time,$projName,$tN,$br,$Configuration,$Platform) | where { $_ }) -join '.'
-  $env:lastBuildLog = Join-Path $resultDir "build.$suffixName"
-  $logFileBuildBL = Join-Path $resultDir "build.$suffixName.binlog"
-  $logFileName = Join-Path $resultDir "build.$suffixName"
-  $logErrFileName = "$logFileName.err"
-  $logTxtFileName = Join-Path $resultDir "build.$suffixName.log"
-  Write-Verbose "ErrFileName: $logErrFileName"
-  $logWrnFileName = "$logFileName.wrn"
-  Write-Verbose "WrnFileName: $logWrnFileName"
-  $logDurationFile = Join-Path $resultDir "build.$suffixName.txt"
-  $logExitLevelFile = Join-Path $resultDir "build.$suffixName.exitcode"
-
-  if ($clean) {
-    git clean -dfx .
-    $script:errorLevel = $LASTEXITCODE
-    if (0 -ne $script:errorLevel) {
-      Write-Error "Cannot clean, error code ${script:errorLevel}"
-      return
-    }
-  }
-
-  $hasCppPackages = $false
-  if ($projectItem.Extension.StartsWith(".sln")) {
-    $firstConfigFile = Get-ChildItem packages.config -Path $dir -File -Recurse -Depth 4 | Select-Object -First 1
-    $hasCppPackages = $null -ne $firstConfigFile
-    if ($hasCppPackages) {
-      $packagesDir = Join-Path $dir 'packages'
-    } else {
-      $packagesDir = Get-GlobalPackagesFolder -dir $dir
-    }
-    if (($null -ne $packagesDir) -and (Test-Path env:NUGET_PACKAGES)) {
-      $nugetPackagesTarget = $env:NUGET_PACKAGES
-    } elseif ($null -ne $packagesDir) {
-      $nugetPackagesTarget = "$env:USERPROFILE\.nuget\packages"
-    }
-    if (($null -ne $nugetPackagesTarget) -and $script:canCreateSymLinks) {
-      Write-Verbose "SymLink $packagesDir -> $nugetPackagesTarget"
-      $existingItem = Get-Item -LiteralPath $packagesDir -Force -ErrorAction SilentlyContinue
-      if ($null -ne $existingItem) {
-        $isSymLink = $existingItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint
-        if ([System.IO.FileAttributes]::ReparsePoint -ne $isSymLink) {
-          # Real directory/file - remove it
-          Remove-Item $packagesDir -Rec -Force
-        } else {
-          # Symlink (valid or broken) - remove so New-Item can replace it
-          Remove-Item -LiteralPath $packagesDir -Force
-        }
-      }
-      New-Item $packagesDir -ItemType SymbolicLink -Target $nugetPackagesTarget -Force | Out-Null
-    } elseif ($null -ne $nugetPackagesTarget) {
-      Write-Verbose "Skipping symlink for packages dir (symlinks not available on this machine)"
-    }
-  }
-
-  if ($hasCppPackages) {
-    $script:msBuildArgs += "/p:RestorePackagesConfig=true"
-  }
-
-  Write-Verbose ("MSBuild params:{0}" -f ($script:msBuildArgs -join ' '))
-
-  if ($noBuild) {
-    Write-Host "No build, nothing else todo"
-  }
-
-  Write-Verbose "LogFile:$logFileBuildBL"
-  $script:start = [DateTime]::Now
-  msbuild $projectItem.FullName "-bl:LogFile=$LogFileBuildBL" "-flp:Logfile=$LogTxtFileName;Verbosity=$Verbosity" "-flp2:LogFile=$logErrFileName;errorsonly" "-flp3:LogFile=$logWrnFileName;warningsonly" "/v:$Verbosity" @msbuildArgs
-  $script:errorLevel = $LASTEXITCODE
-  $script:end = [DateTime]::Now
+  # No Gradle detected — fall through to MSBuild.
+  Write-Verbose "No Gradle wrapper detected; dispatching to MSBuild."
+  $msBuildParams = @{} + $PSBoundParameters
+  # Remove Gradle-only params before forwarding
+  $msBuildParams.Remove('Tasks') | Out-Null
+  & "$PSScriptRoot\Invoke-MsBuild.ps1" @msBuildParams
 }
-
-end {
-  Write-Verbose "End"
-
-  function Write-Url {
-    param(
-      $message,
-      $file)
-
-    $esc = [char]27  # Escape character (ESC), compatible with PS5.1+
-    $sequence = "${esc}]8;;$file`a$message${esc}]8;;`a"
-    Write-Host $sequence
-  }
-
-  if ($null -ne $script:end -and $null -ne $script:start) {
-    $duration = $script:end - $script:start
-    $durationStr = $duration.ToString("hh\:mm\:ss\.fff")
-    Write-Verbose "Duration:$durationStr"
-    Set-Content -Value $durationStr -Path $logDurationFile
-  }
-
-  if ($null -ne $logExitLevelFile) {
-    Set-Content -Value $errorLevel -Path $logExitLevelFile
-  }
-
-  if (($null -ne $logErrFileName) -and (Test-Path $logErrFileName)) {
-    Get-Content $logErrFileName | Write-Host
-  }
-  if (($null -ne $logFileBuildBL) -and (Test-Path $logFileBuildBL)) {
-    Write-Url -Message "$logFileBuildBL" -File $logFileBuildBL
-  }
-  Write-Verbose "End build for $dir"
-
-  Write-Verbose ("Exiting with error level {0}" -f $script:errorlevel)
-  if ($script:errorLevel -ne 0)
-  {
-    Write-Error "Build failed with error code: $script:errorLevel"
-  }
-
-  Exit $script:errorlevel
-}
-

--- a/Invoke-GradleBuild.ps1
+++ b/Invoke-GradleBuild.ps1
@@ -6,7 +6,6 @@ param(
 )
 
 begin {
-    # Walk up from cwd to repo root (.git boundary) looking for the Gradle wrapper.
     function Find-GradleWrapper {
         [CmdletBinding()]
         param()
@@ -20,19 +19,16 @@ begin {
                 Write-Verbose "Found Gradle wrapper: $candidate"
                 return $candidate
             }
-            # Stop at repo root
             if (Test-Path (Join-Path $dir '.git')) {
                 Write-Verbose "Reached .git boundary at $dir; wrapper not found."
                 return $null
             }
             $parent = Split-Path $dir -Parent
-            if ($parent -eq $dir) { return $null }   # filesystem root
+            if ($parent -eq $dir) { return $null }
             $dir = $parent
         }
     }
 
-    # Refresh JAVA_HOME / ANDROID_HOME / GRADLE_USER_HOME from the user-scoped registry
-    # so sessions that predate setup-android-env.ps1 pick them up.
     function Refresh-AndroidEnvVars {
         [CmdletBinding()]
         param()
@@ -46,7 +42,6 @@ begin {
             }
         }
 
-        # Ensure JAVA_HOME\bin is on PATH so gradlew can find java.
         if ($env:JAVA_HOME) {
             $javaBin = Join-Path $env:JAVA_HOME 'bin'
             if ($env:PATH -notlike "*$javaBin*") {
@@ -64,14 +59,34 @@ begin {
 
     Refresh-AndroidEnvVars
 
-    # Remove HTTP_PROXY / HTTPS_PROXY — empty string causes a parse error in
-    # Java's proxy stack (sdkmanager, Gradle HTTP client).  Remove entirely.
     $savedHttpProxy  = $env:HTTP_PROXY
     $savedHttpsProxy = $env:HTTPS_PROXY
     Remove-Item Env:HTTP_PROXY  -ErrorAction SilentlyContinue
     Remove-Item Env:HTTPS_PROXY -ErrorAction SilentlyContinue
     $env:JAVA_TOOL_OPTIONS = '-Djava.net.useSystemProxies=false'
     Write-Verbose "Cleared HTTP_PROXY / HTTPS_PROXY for Gradle JVM"
+
+    # Mirror the .vs log directory convention from Invoke-MsBuild.ps1
+    $repoRoot = & "$PSScriptRoot\Get-RepoRoot.ps1"
+    $resultDir = Join-Path $repoRoot '.vs'
+    New-Item $resultDir -ItemType Directory -ErrorAction Ignore | Out-Null
+
+    $time     = [datetime]::Now.ToString("yy.dd.MM-HH.mm.ss")
+    $projName = Split-Path (Get-Location).Path -Leaf
+    $br       = (git branch --show-current 2>$null) -split '/' | Select-Object -Last 1
+    $taskStr  = ($Tasks -join '_') -replace '[\\/:*?"<>|]', '_'
+
+    $suffixName       = (($time, $projName, $taskStr, $br, $Configuration) | Where-Object { $_ }) -join '.'
+    $logTxtFileName   = Join-Path $resultDir "build.$suffixName.log"
+    $logErrFileName   = Join-Path $resultDir "build.$suffixName.err"
+    $logWrnFileName   = Join-Path $resultDir "build.$suffixName.wrn"
+    $logDurationFile  = Join-Path $resultDir "build.$suffixName.txt"
+    $logExitLevelFile = Join-Path $resultDir "build.$suffixName.exitcode"
+
+    $env:lastBuildLog = Join-Path $resultDir "build.$suffixName"
+    Write-Verbose "Log base: $($env:lastBuildLog)"
+    Write-Verbose "ErrFileName: $logErrFileName"
+    Write-Verbose "WrnFileName: $logWrnFileName"
 }
 
 process {
@@ -81,7 +96,6 @@ process {
         $gradleTasks.Add('clean')
         Write-Verbose "Prepending 'clean' task"
     }
-
     foreach ($t in $Tasks) { $gradleTasks.Add($t) }
 
     $extraArgs = @()
@@ -91,15 +105,51 @@ process {
     }
 
     Write-Verbose "Running: $wrapper $gradleTasks $extraArgs"
-    & $wrapper @gradleTasks @extraArgs
+
+    $script:logLines = [System.Collections.Generic.List[string]]::new()
+    $script:start = [DateTime]::Now
+
+    # Capture all output (stdout + stderr) while streaming to terminal in real time.
+    # Strip ANSI escape codes before writing to log files so they're plain text.
+    & $wrapper @gradleTasks @extraArgs 2>&1 | ForEach-Object {
+        $line = if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.ToString() } else { [string]$_ }
+        Write-Host $line
+        $script:logLines.Add(($line -replace '\x1B\[[0-9;]*[mK]', ''))
+    }
     $script:exitCode = $LASTEXITCODE
+    $script:end = [DateTime]::Now
 }
 
 end {
-    # Restore proxy vars
     if ($savedHttpProxy)  { $env:HTTP_PROXY  = $savedHttpProxy }
     if ($savedHttpsProxy) { $env:HTTPS_PROXY = $savedHttpsProxy }
     Remove-Item Env:JAVA_TOOL_OPTIONS -ErrorAction SilentlyContinue
+
+    $script:logLines | Set-Content -Path $logTxtFileName -Encoding UTF8
+    Write-Verbose "Full log: $logTxtFileName"
+
+    # Gradle/Kotlin/C++ error patterns
+    $errLines = $script:logLines | Where-Object { $_ -match '(?i)(^e:\s|: error:|> Task .+ FAILED|^FAILURE:)' }
+    if ($errLines) {
+        $errLines | Set-Content -Path $logErrFileName -Encoding UTF8
+        Write-Verbose "Error log: $logErrFileName ($(@($errLines).Count) lines)"
+    }
+
+    # Gradle/Kotlin/C++ warning patterns
+    $wrnLines = $script:logLines | Where-Object { $_ -match '(?i)(^w:\s|: warning:|WARNING:)' }
+    if ($wrnLines) {
+        $wrnLines | Set-Content -Path $logWrnFileName -Encoding UTF8
+        Write-Verbose "Warning log: $logWrnFileName ($(@($wrnLines).Count) lines)"
+    }
+
+    if ($null -ne $script:end -and $null -ne $script:start) {
+        $duration    = $script:end - $script:start
+        $durationStr = $duration.ToString("hh\:mm\:ss\.fff")
+        Write-Verbose "Duration: $durationStr"
+        Set-Content -Value $durationStr -Path $logDurationFile
+    }
+
+    Set-Content -Value $script:exitCode -Path $logExitLevelFile
 
     if ($script:exitCode -ne 0) {
         Write-Error "Gradle build failed with exit code $script:exitCode"

--- a/Invoke-GradleBuild.ps1
+++ b/Invoke-GradleBuild.ps1
@@ -1,0 +1,108 @@
+[CmdletBinding()]
+param(
+    [string[]] $Tasks = @('build'),
+    [string]   $Configuration,
+    [switch]   $Clean
+)
+
+begin {
+    # Walk up from cwd to repo root (.git boundary) looking for the Gradle wrapper.
+    function Find-GradleWrapper {
+        [CmdletBinding()]
+        param()
+
+        $wrapperName = if ($IsWindows) { 'gradlew.bat' } else { 'gradlew' }
+        $dir = (Get-Location).Path
+
+        while ($true) {
+            $candidate = Join-Path $dir $wrapperName
+            if (Test-Path $candidate) {
+                Write-Verbose "Found Gradle wrapper: $candidate"
+                return $candidate
+            }
+            # Stop at repo root
+            if (Test-Path (Join-Path $dir '.git')) {
+                Write-Verbose "Reached .git boundary at $dir; wrapper not found."
+                return $null
+            }
+            $parent = Split-Path $dir -Parent
+            if ($parent -eq $dir) { return $null }   # filesystem root
+            $dir = $parent
+        }
+    }
+
+    # Refresh JAVA_HOME / ANDROID_HOME / GRADLE_USER_HOME from the user-scoped registry
+    # so sessions that predate setup-android-env.ps1 pick them up.
+    function Refresh-AndroidEnvVars {
+        [CmdletBinding()]
+        param()
+
+        $regPath = 'HKCU:\Environment'
+        foreach ($var in 'JAVA_HOME','ANDROID_HOME','GRADLE_USER_HOME') {
+            $regVal = (Get-ItemProperty -Path $regPath -Name $var -ErrorAction SilentlyContinue).$var
+            if ($regVal -and -not (Test-Path "Env:$var")) {
+                Set-Item "Env:$var" $regVal
+                Write-Verbose "Restored $var = $regVal (from registry)"
+            }
+        }
+
+        # Ensure JAVA_HOME\bin is on PATH so gradlew can find java.
+        if ($env:JAVA_HOME) {
+            $javaBin = Join-Path $env:JAVA_HOME 'bin'
+            if ($env:PATH -notlike "*$javaBin*") {
+                $env:PATH = "$javaBin;$env:PATH"
+                Write-Verbose "Prepended $javaBin to PATH"
+            }
+        }
+    }
+
+    $wrapper = Find-GradleWrapper
+    if (-not $wrapper) {
+        Write-Error "No Gradle wrapper (gradlew.bat / gradlew) found in this directory or any parent up to the repo root."
+        exit 1
+    }
+
+    Refresh-AndroidEnvVars
+
+    # Remove HTTP_PROXY / HTTPS_PROXY — empty string causes a parse error in
+    # Java's proxy stack (sdkmanager, Gradle HTTP client).  Remove entirely.
+    $savedHttpProxy  = $env:HTTP_PROXY
+    $savedHttpsProxy = $env:HTTPS_PROXY
+    Remove-Item Env:HTTP_PROXY  -ErrorAction SilentlyContinue
+    Remove-Item Env:HTTPS_PROXY -ErrorAction SilentlyContinue
+    $env:JAVA_TOOL_OPTIONS = '-Djava.net.useSystemProxies=false'
+    Write-Verbose "Cleared HTTP_PROXY / HTTPS_PROXY for Gradle JVM"
+}
+
+process {
+    $gradleTasks = [System.Collections.Generic.List[string]]::new()
+
+    if ($Clean) {
+        $gradleTasks.Add('clean')
+        Write-Verbose "Prepending 'clean' task"
+    }
+
+    foreach ($t in $Tasks) { $gradleTasks.Add($t) }
+
+    $extraArgs = @()
+    if ($Configuration) {
+        $extraArgs += "-PbuildType=$Configuration"
+        Write-Verbose "Passing -PbuildType=$Configuration"
+    }
+
+    Write-Verbose "Running: $wrapper $gradleTasks $extraArgs"
+    & $wrapper @gradleTasks @extraArgs
+    $script:exitCode = $LASTEXITCODE
+}
+
+end {
+    # Restore proxy vars
+    if ($savedHttpProxy)  { $env:HTTP_PROXY  = $savedHttpProxy }
+    if ($savedHttpsProxy) { $env:HTTPS_PROXY = $savedHttpsProxy }
+    Remove-Item Env:JAVA_TOOL_OPTIONS -ErrorAction SilentlyContinue
+
+    if ($script:exitCode -ne 0) {
+        Write-Error "Gradle build failed with exit code $script:exitCode"
+    }
+    exit $script:exitCode
+}

--- a/Invoke-MsBuild.ps1
+++ b/Invoke-MsBuild.ps1
@@ -1,0 +1,312 @@
+[CmdLetBinding()]
+param(
+  [switch]$NoRestore,
+  [switch]$clean,
+  [switch]$noBuild,
+  [switch]$noParallel,
+  [switch]$rawOutput,
+  [switch]$noConsoleLoger,
+  [switch]$enableAutoResponse,
+  [string]$Id = "",
+  $baseResultDir = $null,
+  $Project = "auto",
+  [string]$Target,
+  [Parameter()]
+  [hashtable]$Properties = @{},
+  [Parameter()]
+  [ArgumentCompleter({
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+      'Release','Debug' | Where-Object { $_ -like "$wordToComplete*" }
+    })]
+  [string]$Configuration,
+  [Parameter()]
+  [ArgumentCompleter({
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+      'ARM64ec','x64','x86','ARM64','AnyCPU' | Where-Object { $_ -like "$wordToComplete*" }
+    })]
+  [string]$Platform,
+  [Parameter()]
+  [ValidateSet('Quiet','Minimal','Normal','Detailed','Diagnostic')]
+  [ArgumentCompleter({
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+      'Quiet','Minimal','Normal','Detailed','Diagnostic' |
+        Where-Object { $_ -like "$wordToComplete*" }
+    })]
+  [string]$ConsoleVerbosity = "Minimal",
+  [Parameter()]
+  [ValidateSet('Quiet','Minimal','Normal','Detailed','Diagnostic')]
+  [ArgumentCompleter({
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+      'Quiet','Minimal','Normal','Detailed','Diagnostic' |
+        Where-Object { $_ -like "$wordToComplete*" }
+    })]
+  [string]$Verbosity='Diagnostic',
+  [string]$ConsoleLoggerParameters = "Verbosity=${ConsoleVerbosity}"
+)
+
+begin {
+  function Test-IsGitRepo { ($null -ne (Get-RepoRoot)) }
+
+  function Test-SymLinks {
+    $testDir = [System.IO.Path]::GetTempPath()
+    $testLink = Join-Path $testDir "symlink-test-$PID"
+    $testTarget = Join-Path $testDir "symlink-target-$PID"
+    try {
+      New-Item -ItemType Directory -Path $testTarget -Force | Out-Null
+      New-Item -ItemType SymbolicLink -Path $testLink -Target $testTarget -ErrorAction Stop | Out-Null
+      return $true
+    } catch {
+      return $false
+    } finally {
+      Remove-Item -LiteralPath $testLink -Force -ErrorAction SilentlyContinue
+      Remove-Item -LiteralPath $testTarget -Force -ErrorAction SilentlyContinue
+    }
+  }
+
+  $script:canCreateSymLinks = Test-SymLinks
+  Write-Verbose "SymLink support: $script:canCreateSymLinks"
+
+  Write-Verbose "Begin"
+
+  # If running inside WSL and the repo contains C++ projects, re-run on the Windows side.
+  if ($env:WSL_DISTRO_NAME) {
+    if (Get-ChildItem *.vcxproj -File -Recurse -Depth 3 | Select-Object -First 1) {
+      Invoke-OnWindowsIfWsl -ScriptPath $MyInvocation.MyCommand.Path -BoundParameters $PSBoundParameters
+    }
+  }
+
+  Enter-VsShell | Write-Verbose
+
+  $script:errorLevel = 0
+
+  if (-not $PSBoundParameters.ContainsKey('baseResultDir')) {
+    $baseResultDir = Join-Path (Get-RepoRoot) '.vs'
+  }
+
+  if (-Not (Test-Path $baseResultDir)) {
+    New-Item $baseResultDir -ItemType Directory | Out-Null
+  }
+
+  $script:msBuildArgs = @()
+
+  if (-Not $noParallel) {
+    Write-Verbose "Running in parallel"
+    $msbuildArgs += "/m"
+  }
+  if (-Not $rawOutput) {
+    Write-Verbose "Using new terminal output"
+    $msbuildArgs += "/tl"
+  }
+  if (-Not $enableAutoResponse) {
+    Write-Verbose "Not using auto response files"
+    $msbuildArgs += "-noautoresponse"
+  }
+  if ($noConsoleLogger) {
+    Write-Verbose "Disabling console logger"
+    $msbuildArgs += "-noconsolelogger"
+  }
+  if ("" -ne $ConsoleLoggerParameters) {
+    Write-Verbose "Settings console logging parameters:$ConsoleLoggerParameters"
+    $msbuildArgs += "-clp:$ConsoleLoggerParameters"
+  }
+  if ("" -ne $Target) {
+    Write-Verbose "Build target:$Target"
+    $msbuildArgs += "/t:$Target"
+  }
+
+  # Build the /p: arguments
+  $msBuildArgs += $Properties.GetEnumerator() | ForEach-Object {
+    $key = $_.Key
+    $value = $_.Value
+    Write-Verbose "Setting property: $key -> $value"
+    "/p:$Key=$Value"
+  }
+
+  if (("" -eq $Platform) -and (Test-IsGitRepo)) {
+    Write-Verbose "Setting platform:$Platform"
+    $hasCpp = Get-ChildItem *.vcxproj -File -Recurse -Depth 3 | Select-Object -First 1
+    if ($hasCpp) {
+      $Platform = if ($hasCpp) { $env:PROCESSOR_ARCHITECTURE } else { "AnyCPU" }
+      if ($Platform -eq "AMD64") { $Platform = "X64" }
+    }
+  }
+  if ("" -ne $Platform) {
+    $msBuildArgs += "/p:Platform=$Platform"
+    Write-Verbose "Platform:$Platform"
+  }
+
+  if ("" -ne $Configuration) {
+    Write-Verbose "Setting config:$Configuration"
+    $msBuildArgs += "/p:Configuration=$Configuration"
+  }
+
+  if ((-Not $NoRestore)) {
+    Write-Verbose "Setting restore flag"
+    $msBuildArgs += "-restore"
+  }
+
+  $bPath = (pwd).Path
+  $dir = $bPath
+
+  if ("auto" -eq $Project) {
+    Write-Verbose ("Looking for project in directory:{0}" -f $dir)
+    $projectItem = Get-ChildItem -File (
+      (Join-Path $dir '*.sln*'),
+      (Join-Path $dir '*.*proj')) | Select-Object -First 1
+    if ($null -eq $projectItem) {
+      Write-Error "Project not found in $dir"
+      $script:errorLevel = 404
+      return
+    }
+  } else {
+    $projectItem = Get-Item $Project
+  }
+
+  $script:errorLevel = 0
+}
+
+process {
+
+  function Get-GlobalPackagesFolder {
+    param($dir)
+    $nugetConfigPath = Join-Path $dir 'nuget.config'
+    if (Test-Path $nugetConfigPath) {
+      $nugetGConfig = [xml](Get-Content $nugetConfigPath)
+      $nugetConfig = $nugetGConfig.configuration.config.add
+      if ($null -ne $nugetConfig) {
+        return $nugetConfig.GetEnumerator() | where { $_.key -eq "globalPackagesFolder" } | select -ExpandProperty value
+      }
+    }
+    return $null
+  }
+
+  if (0 -ne $script:errorLevel) {
+    Write-Verbose ("Already failed with error code {0}" -f $script:errorLevel)
+    return
+  }
+
+  Write-Verbose ("Building project:{0}" -f $projectItem.FullName)
+
+  $time = [datetime]::Now.ToString("yy.dd.MM-HH.mm.ss")
+  $br = git branch --show-current
+  $br = ($br -split '/') | Select-Object -Last 1
+  if ("" -ne $id) {
+    $br += ".$id"
+  }
+
+  $projName = $projectItem.BaseName
+  $resultDir = "$baseResultDir"
+  New-Item $resultDir -ItemType Directory -ErrorAction Ignore | Out-Null
+  $tN = ($target -split '\\') | Select-Object -Last 1
+  $tN = $tN.Replace(":",".")
+  $suffixName = (($time,$projName,$tN,$br,$Configuration,$Platform) | where { $_ }) -join '.'
+  $env:lastBuildLog = Join-Path $resultDir "build.$suffixName"
+  $logFileBuildBL = Join-Path $resultDir "build.$suffixName.binlog"
+  $logFileName = Join-Path $resultDir "build.$suffixName"
+  $logErrFileName = "$logFileName.err"
+  $logTxtFileName = Join-Path $resultDir "build.$suffixName.log"
+  Write-Verbose "ErrFileName: $logErrFileName"
+  $logWrnFileName = "$logFileName.wrn"
+  Write-Verbose "WrnFileName: $logWrnFileName"
+  $logDurationFile = Join-Path $resultDir "build.$suffixName.txt"
+  $logExitLevelFile = Join-Path $resultDir "build.$suffixName.exitcode"
+
+  if ($clean) {
+    git clean -dfx .
+    $script:errorLevel = $LASTEXITCODE
+    if (0 -ne $script:errorLevel) {
+      Write-Error "Cannot clean, error code ${script:errorLevel}"
+      return
+    }
+  }
+
+  $hasCppPackages = $false
+  if ($projectItem.Extension.StartsWith(".sln")) {
+    $firstConfigFile = Get-ChildItem packages.config -Path $dir -File -Recurse -Depth 4 | Select-Object -First 1
+    $hasCppPackages = $null -ne $firstConfigFile
+    if ($hasCppPackages) {
+      $packagesDir = Join-Path $dir 'packages'
+    } else {
+      $packagesDir = Get-GlobalPackagesFolder -dir $dir
+    }
+    if (($null -ne $packagesDir) -and (Test-Path env:NUGET_PACKAGES)) {
+      $nugetPackagesTarget = $env:NUGET_PACKAGES
+    } elseif ($null -ne $packagesDir) {
+      $nugetPackagesTarget = "$env:USERPROFILE\.nuget\packages"
+    }
+    if (($null -ne $nugetPackagesTarget) -and $script:canCreateSymLinks) {
+      Write-Verbose "SymLink $packagesDir -> $nugetPackagesTarget"
+      $existingItem = Get-Item -LiteralPath $packagesDir -Force -ErrorAction SilentlyContinue
+      if ($null -ne $existingItem) {
+        $isSymLink = $existingItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint
+        if ([System.IO.FileAttributes]::ReparsePoint -ne $isSymLink) {
+          # Real directory/file - remove it
+          Remove-Item $packagesDir -Rec -Force
+        } else {
+          # Symlink (valid or broken) - remove so New-Item can replace it
+          Remove-Item -LiteralPath $packagesDir -Force
+        }
+      }
+      New-Item $packagesDir -ItemType SymbolicLink -Target $nugetPackagesTarget -Force | Out-Null
+    } elseif ($null -ne $nugetPackagesTarget) {
+      Write-Verbose "Skipping symlink for packages dir (symlinks not available on this machine)"
+    }
+  }
+
+  if ($hasCppPackages) {
+    $script:msBuildArgs += "/p:RestorePackagesConfig=true"
+  }
+
+  Write-Verbose ("MSBuild params:{0}" -f ($script:msBuildArgs -join ' '))
+
+  if ($noBuild) {
+    Write-Host "No build, nothing else todo"
+  }
+
+  Write-Verbose "LogFile:$logFileBuildBL"
+  $script:start = [DateTime]::Now
+  msbuild $projectItem.FullName "-bl:LogFile=$LogFileBuildBL" "-flp:Logfile=$LogTxtFileName;Verbosity=$Verbosity" "-flp2:LogFile=$logErrFileName;errorsonly" "-flp3:LogFile=$logWrnFileName;warningsonly" "/v:$Verbosity" @msbuildArgs
+  $script:errorLevel = $LASTEXITCODE
+  $script:end = [DateTime]::Now
+}
+
+end {
+  Write-Verbose "End"
+
+  function Write-Url {
+    param(
+      $message,
+      $file)
+
+    $esc = [char]27  # Escape character (ESC), compatible with PS5.1+
+    $sequence = "${esc}]8;;$file`a$message${esc}]8;;`a"
+    Write-Host $sequence
+  }
+
+  if ($null -ne $script:end -and $null -ne $script:start) {
+    $duration = $script:end - $script:start
+    $durationStr = $duration.ToString("hh\:mm\:ss\.fff")
+    Write-Verbose "Duration:$durationStr"
+    Set-Content -Value $durationStr -Path $logDurationFile
+  }
+
+  if ($null -ne $logExitLevelFile) {
+    Set-Content -Value $errorLevel -Path $logExitLevelFile
+  }
+
+  if (($null -ne $logErrFileName) -and (Test-Path $logErrFileName)) {
+    Get-Content $logErrFileName | Write-Host
+  }
+  if (($null -ne $logFileBuildBL) -and (Test-Path $logFileBuildBL)) {
+    Write-Url -Message "$logFileBuildBL" -File $logFileBuildBL
+  }
+  Write-Verbose "End build for $dir"
+
+  Write-Verbose ("Exiting with error level {0}" -f $script:errorlevel)
+  if ($script:errorLevel -ne 0)
+  {
+    Write-Error "Build failed with error code: $script:errorLevel"
+  }
+
+  Exit $script:errorlevel
+}

--- a/PwrDev.format.ps1xml
+++ b/PwrDev.format.ps1xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>PwrDev.BuildDiagnostic.Table</Name>
+      <ViewSelectedBy>
+        <TypeName>PwrDev.BuildDiagnostic</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <AutoSize/>
+        <TableHeaders>
+          <TableColumnHeader><Label>Sev</Label><Width>7</Width></TableColumnHeader>
+          <TableColumnHeader><Label>File</Label><Width>40</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Line</Label><Width>6</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Col</Label><Width>5</Width><Alignment>Right</Alignment></TableColumnHeader>
+          <TableColumnHeader><Label>Code</Label><Width>10</Width></TableColumnHeader>
+          <TableColumnHeader><Label>Message</Label></TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem><PropertyName>Severity</PropertyName></TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  if ($_.File -is [System.IO.FileSystemInfo]) { $_.File.Name } else { $_.File }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem><PropertyName>LineNumber</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Column</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Code</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>Message</PropertyName></TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>

--- a/PwrDev.psm1
+++ b/PwrDev.psm1
@@ -1,4 +1,6 @@
 
+Update-FormatData -PrependPath $PSScriptRoot\PwrDev.format.ps1xml
+
 set-alias Get-RepoRoot $PSScriptRoot\Get-RepoRoot.ps1 -scope global
 Export-ModuleMember -Alias Get-RepoRoot
 

--- a/PwrDev.psm1
+++ b/PwrDev.psm1
@@ -35,12 +35,20 @@ Export-ModuleMember -Alias Enter-VsShell
 set-alias build $PSScriptRoot\Invoke-BuildTool.ps1 -scope global
 Export-ModuleMember -Alias build
 
+set-alias gradle-build $PSScriptRoot\Invoke-GradleBuild.ps1 -scope global
+Export-ModuleMember -Alias gradle-build
+
+set-alias gradle $PSScriptRoot\Invoke-GradleBuild.ps1 -scope global
+Export-ModuleMember -Alias gradle
+
+set-alias msbuild $PSScriptRoot\Invoke-MsBuild.ps1 -scope global
+Export-ModuleMember -Alias msbuild
+
 set-alias test-build $PSScriptRoot\Test-Build.ps1 -scope global
 Export-ModuleMember -Alias test-build
 
 $global:_pwrdev_aliases = (
   'devenv',
-  'msbuild',
   'deployapprecipe'
 )
 


### PR DESCRIPTION
- Invoke-MsBuild.ps1: extracted verbatim from Invoke-BuildTool.ps1 (MSBuild logic unchanged)
- Invoke-GradleBuild.ps1: cross-platform Gradle wrapper (detects gradlew/gradlew.bat, walks
  up to .git, refreshes JAVA_HOME/ANDROID_HOME from registry, removes HTTP_PROXY/HTTPS_PROXY
  to avoid Java proxy parse errors, restores on exit)
- Invoke-BuildTool.ps1: rewritten as thin dispatcher (Gradle wrapper detected first, then
  falls back to MSBuild)
- PwrDev.psm1: add gradle, gradle-build, msbuild aliases; remove msbuild from _pwrdev_aliases

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
